### PR TITLE
Wrap GraphTraits in llvm namespace for older gcc

### DIFF
--- a/mlir/lib/Transforms/LoopRestructure.cpp
+++ b/mlir/lib/Transforms/LoopRestructure.cpp
@@ -82,8 +82,9 @@ using namespace mlir;
 
 #define DEBUG_TYPE "LoopRestructure"
 
+namespace llvm {
 template <>
-struct llvm::GraphTraits<const mlir::Block *> {
+struct GraphTraits<const mlir::Block *> {
   using ChildIteratorType = mlir::Block::succ_iterator;
   using Node = const mlir::Block;
   using NodeRef = Node *;
@@ -97,6 +98,7 @@ struct llvm::GraphTraits<const mlir::Block *> {
     return const_cast<mlir::Block *>(node)->succ_end();
   }
 };
+}
 
 namespace {
 


### PR DESCRIPTION
Otherwise gcc 6.2 will raise error.